### PR TITLE
[hotfix] fix_existing owner's painting not loading.

### DIFF
--- a/config/socketEventHandlers/handleCanvasEvent.js
+++ b/config/socketEventHandlers/handleCanvasEvent.js
@@ -1,4 +1,14 @@
 function handleCanvasEvent(socket) {
+  socket.on("getOwnersCanvas", () => {
+    socket
+      .to(socket.ownerSocketId)
+      .emit("getOwnersCanvas", { requestorSocketId: socket.id });
+  });
+
+  socket.on("sendOwnersCanvas", ({ ownersCanvas, requestorSocketId }) => {
+    socket.to(requestorSocketId).emit("sendOwnersCanvas", { ownersCanvas });
+  });
+
   socket.on("drawing", ({ pathData, room }) => {
     socket.broadcast.to(room).emit("drawing", pathData);
   });


### PR DESCRIPTION
## 칸반 카드번호
none
## 칸반 카드 링크
none
## 구현내용
- 기존 주최자의 그림이 후속 참여자에게 보이지 않는 문제를 해결했습니다. 